### PR TITLE
Rename web container_name for clarity

### DIFF
--- a/docker-compose.web.yml
+++ b/docker-compose.web.yml
@@ -1,6 +1,6 @@
 services:
   web:
-    container_name: torborepo-starter-web
+    container_name: portfolio-web
     image: web:latest
     build:
       context: .


### PR DESCRIPTION
## Overview

This Pull Request renames the `container_name` for the web service in `docker-compose.web.yml` from `torborepo-starter-web` to `portfolio-web`. This change ensures consistent and clear container naming across the project, aligning with the actual project name.

## Changes
- **Renamed** the web service container from `torborepo-starter-web` to `portfolio-web` in `docker-compose.web.yml`.

## Review Priority
- [x] Low (Review when you have time)

## Related Issues/Projects
- No related issues or projects.

## Breaking Changes
- [ ] Yes (details below)
- [x] No

## Impact Scope
- [ ] UI changes
- [ ] Database changes
- [ ] API changes
- [x] Configuration changes
- [ ] Environment variable changes
- [ ] None (Code cleanup)

## Testing
### Build/Test
- [x] Docker compose up for web service completes successfully.
- [x] The web service starts with the new container name.

## Screenshots
- No UI changes.

## Deployment Steps
- [x] Can be handled with normal deployment procedure.

## Notes
- This is a minor configuration update for naming consistency.
- No impact on application logic or environment variables.
